### PR TITLE
修复 链接指向错误

### DIFF
--- a/source/docs/shapes/Text.md
+++ b/source/docs/shapes/Text.md
@@ -2,7 +2,7 @@ title: HTML5 canvas 添加文本教程
 ---
 要使用`Konva`添加文本, 我们可以实例化一个`Konva.Text()`对象.
 
-有关属性和方法的完整列表,请参阅[Konva.Text]((https://konvajs.github.io/api/Konva.Text.html)文档
+有关属性和方法的完整列表,请参阅[Konva.Text](https://konvajs.github.io/api/Konva.Text.html)文档
 
 
 {% iframe /downloads/code/shapes/Text.html %}


### PR DESCRIPTION
修复 链接错误 (多了一个左括号) 导致页面上的跳转链接 404
当前页面上的链接指向为 : https://konvajs.com/docs/shapes/(https://konvajs.github.io/api/Konva.Text.html